### PR TITLE
add eclipse plugins

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -169,6 +169,25 @@ rec {
     };
   };
 
+  cdt_9_0_1 = buildEclipseUpdateSite rec {
+    name = "cdt-${version}";
+    version = "9.0.1";
+
+    src = fetchzip {
+      stripRoot = false;
+      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/tools/cdt/releases/9.0/${name}.zip";
+      sha256 = "0vdx0j9ci533wnk7y17qjvjyqx38hlrdw67z6pi05vfv3r6ys39x";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://eclipse.org/cdt/;
+      description = "C/C++ development tooling";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
   checkstyle = buildEclipseUpdateSite rec {
     name = "checkstyle-${version}";
     version = "6.19.1.201607051943";
@@ -413,6 +432,29 @@ rec {
       description = "The Eclipse Visualization Toolkit";
       platforms = platforms.all;
       maintainers = [ maintainers.romildo ];
+    };
+  };
+
+ rustdt = buildEclipseUpdateSite rec {
+    name = "rustdt-${version}";
+    version = "0.6.2";
+
+    src = fetchzip {
+      stripRoot = false;
+      url = "https://github.com/RustDT/rustdt.github.io/archive/master.zip";
+      sha256 = "1k81haikc92myi5ac322j7w40rybxiabcl6ih6b60cw96cgy4ix8";
+      extraPostFetch =
+        ''
+        mv "$out/rustdt.github.io-master/releases/local-repo"/* "$out/"
+        '';
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://rustdt.github.io/releases/;
+      description = "rust development tooling";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.bjornfor ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

building eclipse rustdt

added eclipse cdt plugin 9.0.1

added rustdt plugin

usage
  packageOverrides = pkgs: rec {
    rustdtEclipse = with pkgs.eclipses; with plugins; eclipseWithPlugins {
      eclipse = eclipse-platform;
      jvmArgs = [ "-Xmx2048m" ];
      plugins = [ cdt_9_0_1 rustdt ];
    };
  };
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cdt_9_0_1
rustdt
