### PR TITLE
prevent directory conflict when building docker images with multiple packages

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -165,7 +165,7 @@ EOF
       if [ -n "$contents" ]; then
         echo Adding contents
         for c in $contents; do
-          cp -drf $c/* layer/
+          cp -drf $c/*/ layer/
           chmod -R ug+w layer/
         done
       fi
@@ -193,7 +193,7 @@ EOF
       preMount = lib.optionalString (contents != null) ''
         echo Adding contents
         for c in ${builtins.toString contents}; do
-          cp -drf $c/* layer/
+          cp -drf $c/*/ layer/
           chmod -R ug+w layer/
         done
       '';


### PR DESCRIPTION
###### Motivation for this change

when copying multiple package to a docker images if the top level directories are sym links of the same name the docker image build fails.
added / to cp to resolve the sym link before the copy

following now builds

`cat ~/.nixpkgs/config.nix 
{
  allowUnfree = true;
  packageOverrides = pkgs: rec {
    rustdtEclipse = with pkgs.eclipses; with plugins; eclipseWithPlugins {
      eclipse = eclipse-platform;
      jvmArgs = [ "-Xmx2048m" ];
      plugins = [ cdt_9_0_1 rustdt ];
    };
  };
}
`

`cat rustdt.nix 
with import  <nixpkgs> {};
with dockerTools;
with pkgs;

let
  rustDtImage = buildImage {
    name = "ppickfor/nix-rustdt";
    contents = [
      rustc
      rustfmt
      rustracer
      cargo
      rustdtEclipse
    ];
     runAsRoot = ''
        #!${stdenv.shell}
        mkdir /tmp
        chmod a=rwx,o+t /tmp
      '';
  };
in {
  rustDtDocker = rustDtImage;
}
`
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

pakages
