### PR TITLE
fsharp: 4.0.1.1 -> 4.1.1

### DIFF
--- a/pkgs/development/compilers/fsharp/default.nix
+++ b/pkgs/development/compilers/fsharp/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "fsharp-${version}";
-  version = "4.0.1.1";
+  version = "4.1.1";
 
   src = fetchurl {
     url = "https://github.com/fsharp/fsharp/archive/${version}.tar.gz";
-    sha256 = "0mvmvwwpl4zq0yvgzdizww8l9azvlrc82xm32nz1fi1nw8x5qfqk";
+    sha256 = "0kp0f6d6ggc27lnqhhngxsgls2645z8mqq93gmp2w2z6hcxmhayd";
   };
 
   buildInputs = [ mono pkgconfig dotnetbuildhelpers autoconf automake which ];


### PR DESCRIPTION
###### Motivation for this change

Get new version of F# compiler (just a version number and a sha256 change).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

