### PR TITLE
Fix geoclue build on macOS

### DIFF
--- a/pkgs/development/libraries/geoclue/2.0.nix
+++ b/pkgs/development/libraries/geoclue/2.0.nix
@@ -1,6 +1,8 @@
-{ fetchurl, stdenv, intltool, pkgconfig, glib, json_glib, libsoup, geoip
+{ fetchurl, stdenv, intltool, libintlOrEmpty, pkgconfig, glib, json_glib, libsoup, geoip
 , dbus, dbus_glib, modemmanager, avahi
 }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "geoclue-2.4.3";
@@ -10,23 +12,31 @@ stdenv.mkDerivation rec {
     sha256 = "0pk07k65dlw37nz8z5spksivsv5nh96xmbi336rf2yfxf2ldpadd";
   };
 
-  buildInputs =
+  buildInputs = libintlOrEmpty ++
    [ intltool pkgconfig glib json_glib libsoup geoip
-     dbus dbus_glib modemmanager avahi
-   ];
+     dbus dbus_glib avahi
+   ] ++ optionals (!stdenv.isDarwin) [ modemmanager ];
 
   preConfigure = ''
      substituteInPlace configure --replace "-Werror" ""
   '';
 
-  configureFlags = [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
+  configureFlags = [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ] ++
+                   optionals stdenv.isDarwin [
+                       "--disable-silent-rules"
+                       "--disable-3g-source"
+                       "--disable-cdma-source"
+                       "--disable-modem-gps-source"
+                       "--disable-nmea-source" ];
+
+  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin " -lintl";
 
   propagatedBuildInputs = [ dbus dbus_glib glib ];
 
   meta = with stdenv.lib; {
     description = "Geolocation framework and some data providers";
     maintainers = with maintainers; [ raskin garbas ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     license = licenses.lgpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
geoclue (needed by WebKitGTK+) did not build on MacOS

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

