### PR TITLE
UEFI automated script for partitioning and formatting. to speed up initial set-up time. 

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -95,6 +95,11 @@
   <section xml:id="sec-installation-partitioning-UEFI">
    <title>UEFI (GPT)</title>
 
+    <para>You can automate this process with downloading 
+      <link
+  xlink:href="https://nixos.org/nixos/manual/nixos-UEFI-setup.sh">UEFI partitioning and formating script</link> and modifying it based on your disk under /dev.
+    </para>
+    
    <para>
     Here's an example partition scheme for UEFI, using
     <filename>/dev/sda</filename> as the device.

--- a/nixos/doc/manual/nixos-UEFI-setup.sh
+++ b/nixos/doc/manual/nixos-UEFI-setup.sh
@@ -8,7 +8,7 @@
 
 
 # UNCOMMENT
-DISK_SSD="/dev/nvme0n1"
+#DISK_SSD="/dev/nvme0n1"
 # OR
 #DISK_HDD="/dev/sda"
 NAME_DIVIDER=""

--- a/nixos/doc/manual/nixos-UEFI-setup.sh
+++ b/nixos/doc/manual/nixos-UEFI-setup.sh
@@ -1,0 +1,85 @@
+#! @shell@
+
+# Make sure you uncomment disk you want to set NixOS on sdX(HDD) or nvme0n1(SSD) for example
+# if confused read more on
+# http://tldp.org/HOWTO/html_single/Partition/
+# To check list of avaliable disks run command:
+# lsblk
+
+
+# UNCOMMENT
+DISK_SSD="/dev/nvme0n1"
+# OR
+#DISK_HDD="/dev/sda"
+NAME_DIVIDER=""
+
+echo $DISK_SSD
+if [[ -n $DISK_SSD ]]; then
+    echo "Formating SSD disk to create partitions."
+    DISK=$DISK_SSD
+    NAME_DIVIDER="p"
+
+elif [[ -n $DISK_HDD ]]; then
+    echo "Formating HDD disk to create partitions."
+    DISK=$DISK_HDD
+
+else
+    echo "Uncomment your disk according to your disk name"
+    lsblk
+    exit 1
+fi
+
+
+
+echo ""
+echo "Partitioning "
+echo "Note: You can safely ignore parted's informational message about needing to update /etc/fstab."
+sleep 0.5s
+
+# Create a GPT partition table. 
+parted "$DISK" -- mklabel gpt
+# Add the root partition. This will fill the disk except for the end part, where the swap will live, and the space left in front (512MiB) which will be used by the boot partition. 
+parted "$DISK" -- mkpart primary 512MiB -8GiB
+# Next, add a swap partition. The size required will vary according to needs, here a 8GiB one is created. 
+parted "$DISK" -- mkpart primary linux-swap -8GiB 100%
+# Finally, the boot partition. NixOS by default uses the ESP (EFI system partition) as its /boot partition. It uses the initially reserved 512MiB at the start of the disk. 
+parted "$DISK" -- mkpart ESP fat32 1MiB 512MiB
+parted "$DISK" -- set 3 boot on
+
+echo ""
+echo "Formatting "
+sleep 0.5s
+
+# For initialising Ext4 partitions: mkfs.ext4. It is recommended that you assign a unique symbolic label to the file system using the option -L label, since this makes the file system configuration independent from device changes. For example: 
+mkfs.ext4 -L nixos "${DISK}${NAME_DIVIDER}1"
+# For creating swap partitions: mkswap. Again it’s recommended to assign a label to the swap partition: -L label. For example: 
+mkswap -L swap "${DISK}${NAME_DIVIDER}2"
+# For creating boot partitions: mkfs.fat. Again it’s recommended to assign a label to the boot partition: -n label. For example: 
+mkfs.fat -F 32 -n boot "${DISK}${NAME_DIVIDER}3"
+
+
+echo ""
+echo "Installing "
+sleep 0.5s
+# Mount the target file system on which NixOS should be installed on /mnt, e.g. 
+mount /dev/disk/by-label/nixos /mnt
+# Mount the boot file system on /mnt/boot, e.g. 
+mkdir -p /mnt/boot
+mount /dev/disk/by-label/boot /mnt/boot
+# If your machine has a limited amount of memory, you may want to activate swap devices now (swapon device). The installer (or rather, the build actions that it may spawn) may need quite a bit of RAM, depending on your configuration. 
+swapon "${DISK}${NAME_DIVIDER}2"
+
+# The command nixos-generate-config can generate an initial configuration file for you: 
+nixos-generate-config --root /mnt
+
+echo "More info on https://nixos.org/nixos/manual/index.html#sec-installation-installing "
+echo ""
+echo "You should edit /mnt/etc/nixos/configuration.nix to suit your needs: "
+echo "$ nano /mnt/etc/nixos/configuration.nix "
+echo "or "
+echo "$ vim /mnt/etc/nixos/configuration.nix "
+
+
+
+
+


### PR DESCRIPTION
###### Motivation for this change
I believe that most people have very similar system and if we are talking about UEFI with setting up the defaults, It is pretty much the same every-time. I think there is no reason not to automate this  and provide simple script. Because it is formatting I would like them to read it though and uncoment the disk name. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

This is just a draft for now, it needs to be tested and I need to put script somewhere and link to it. Where should I upload it ? I will test it later but it would be really helpful if somebody will test it as well. :))  