### PR TITLE
python3Packages.fastapi: remove broken patch

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -39,14 +39,6 @@ buildPythonPackage rec {
     aiosqlite
   ];
 
-  # starlette pinning kept in place due to 0.12.9 being a hard
-  # dependency luckily fastapi is currently the only dependent on
-  # starlette. Please remove pinning when possible
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "pydantic >=0.32.2,<=0.32.2" "pydantic"
-  '';
-
   checkPhase = ''
     pytest --ignore=tests/test_default_response_class.py
   '';


### PR DESCRIPTION
###### Motivation for this change
Upstream modified the revision pointed by the current tag (0.45.0) which broke the inline patch.

Pinning is not necessary anymore since upstream now specifies `"pydantic >=0.32.2,<2.0.0"`: https://github.com/tiangolo/fastapi/blob/0.45.0/pyproject.toml#L36

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
