### PR TITLE
gdub: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4036,6 +4036,11 @@
     github = "laikq";
     name = "Gwendolyn Quasebarth";
   };
+  larusso = {
+    email = "manfred.endres@tslarusso.de";
+    github = "larusso";
+    name = "Manfred Endres";
+  };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";

--- a/pkgs/development/tools/build-managers/gdub/default.nix
+++ b/pkgs/development/tools/build-managers/gdub/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, makeWrapper, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "gdub";
+  version = "0.2.0";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "dougborg";
+    repo = "gdub";
+    rev = "v${version}";
+    sha256 = "0ddb5y5n02ajj7n07i8a6v833w67ls9adasvl9zwn73s98fg2w8j";
+  };
+
+  preferLocalBuild = true;
+  dontBuild = true;
+
+  phases = "installPhase";
+  
+  installPhase = ''
+    outdir=$out/share/gdub/bin
+    mkdir -p $outdir
+    cp -r $src/bin/gw $outdir
+    chmod +x $outdir/gw
+    makeWrapper $outdir/gw $out/bin/gw \
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A gradlew / gradle wrapper.";
+    homepage = "https://www.gdub.rocks/";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [maintainers.larusso];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10263,6 +10263,7 @@ in
   gradle_4_10 = res.gradleGen.gradle_4_10;
   gradle_4 = gradle_4_10;
   gradle_5 = res.gradleGen.gradle_5_6;
+  gdub = callPackage ../development/tools/build-managers/gdub { };
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
